### PR TITLE
fix: update cache version from 2 to 3

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Cache Poetry
         id: cache-poetry
-        uses: actions/cache@v2.1.5
+        uses: actions/cache@v3
         with:
           path: ~/.poetry
           key: ${{ matrix.os }}-poetry
@@ -52,7 +52,7 @@ jobs:
 
       - name: Cache dependencies
         id: cache-deps
-        uses: actions/cache@v2.1.5
+        uses: actions/cache@v3
         with:
           path: ${{github.workspace}}/.venv
           key: ${{ matrix.os }}-${{ hashFiles('**/poetry.lock') }}


### PR DESCRIPTION
Hi! I've changed cache version in run_test.yml. Should I add cache in pylama.yml, too? It installs only one dependency now. 